### PR TITLE
install test packages before test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,14 @@ jobs:
       - name: Install APM dependencies
         run: |
           apm ci  # uses locked module. use `apm install` for non-locked
-          apm install ink language-julia
           node script/postinstall.js
       - name: Julia CI
         run: julia -e 'include("ci/packages.jl")'
         shell: bash
-#      - name: Run tests 👩🏾‍💻
-#        run: atom --test spec
+      - name: Run tests 👩🏾‍💻
+        run: |
+          apm install ink language-julia
+          atom --test spec
 
   Lint:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
         shell: bash
       - name: Run tests 👩🏾‍💻
         run: |
-          apm install ink language-julia
+          apm install ink
+          apm install language-julia
           atom --test spec
 
   Lint:


### PR DESCRIPTION
Try this to use install packages before test. I'm not sure why it doesn't work to install the packages in the install step.

Here is an example repo that installs another package for tests:
https://github.com/UziTech/sync-settings-git-location/blob/e7d4bcef581cafb632633a0f89593985c5d70178/.github/workflows/ci.yml#L34